### PR TITLE
modified/added masses to fingerpro_macro

### DIFF
--- a/xacro/pro/fingerpro_macro.xacro
+++ b/xacro/pro/fingerpro_macro.xacro
@@ -70,7 +70,7 @@
                 length_x="0.04"
                 length_y="0.14"
                 length_z="0.04"
-                mass="0.2"
+                mass="0.26"
                 com="0 0.06 0"/>
         </link>
 
@@ -85,7 +85,7 @@
                 length_x="0.04"
                 length_y="0.04"
                 length_z="0.14"
-                mass="0.2"
+                mass="0.25"
                 com="${2 * mesh_x_offset} 0 -0.08"/>
         </link>
 
@@ -100,7 +100,7 @@
                 length_x="0.02"
                 length_y="0.02"
                 length_z="0.14"
-                mass="0.01"
+                mass="0.021"
                 com="0 0 -0.06"/>
         </link>
 
@@ -111,7 +111,7 @@
                 length_y="0.01"
                 length_z="0.01"
                 com="0 0 0"
-                mass="0"/>
+                mass="0.031"/>
         </link>
         <joint name="finger_lower_to_tip_joint${suffix}" type="fixed">
             <parent link="finger_lower_link${suffix}"/>


### PR DESCRIPTION
added tip link mass and modified masses of lower,
middle, and upper link as per the true mass values,
keeping the mass distribution analogous to how it is on
the trifingerone


- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
