### PR TITLE
fix: Explicitly set mass/inertia of visual link to zero

### DIFF
--- a/xacro/pro/fingerpro_macro.xacro
+++ b/xacro/pro/fingerpro_macro.xacro
@@ -89,7 +89,7 @@
                 mass="0.26"
                 com="0 0.06 0"/>
         </link>
-        <link name="finger_upper_link_motor${suffix}">
+        <link name="finger_upper_link_visuals${suffix}">
 
             <!-- motor -->
             <visual>
@@ -127,10 +127,15 @@
                 <material name="fingerpro_motor" />
             </visual>
 
+            <inertial>
+                <mass value="0"/>
+                <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+            </inertial>
+
         </link>
-        <joint name="finger_upper_to_motor_joint${suffix}" type="fixed">
+        <joint name="finger_upper_visuals_joint${suffix}" type="fixed">
             <parent link="finger_upper_link${suffix}"/>
-            <child link="finger_upper_link_motor${suffix}"/>
+            <child link="finger_upper_link_visuals${suffix}"/>
             <origin xyz="0 ${center_offset} 0" />
         </joint>
 
@@ -148,7 +153,7 @@
                 mass="0.25"
                 com="${2 * mesh_x_offset} 0 -0.08"/>
         </link>
-        <link name="finger_middle_link_motor${suffix}">
+        <link name="finger_middle_link_visuals${suffix}">
 
             <!-- motor -->
             <visual>
@@ -186,10 +191,15 @@
                 <material name="fingerpro_motor" />
             </visual>
 
+            <inertial>
+                <mass value="0"/>
+                <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+            </inertial>
+
         </link>
-        <joint name="finger_middle_to_motor_joint${suffix}" type="fixed">
+        <joint name="finger_middle_visuals_joint${suffix}" type="fixed">
             <parent link="finger_middle_link${suffix}"/>
-            <child link="finger_middle_link_motor${suffix}"/>
+            <child link="finger_middle_link_visuals${suffix}"/>
         </joint>
 
         <link name="finger_lower_link${suffix}">


### PR DESCRIPTION
## Description

These links only add visual elements that should not affect the physical
behaviour of the robot.  However, if not specified, pyBullet assumes a
default mass of 1 kg...


## How I Tested

By running demo_control.py (which behaves normal again now).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
