### PR TITLE
doc: Link to trifinger_docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install ruff
-      # Include `--format=github` to enable automatic inline annotations.
+      # Include `--output-format=github` to enable automatic inline annotations.
       - name: Run Ruff
-        run: ruff check --format=github .
+        run: ruff check --output-format=github .
 
   black:
     name: Python Formatting

--- a/doc/breathing_cat.toml
+++ b/doc/breathing_cat.toml
@@ -1,3 +1,6 @@
 [mainpage]
 title = "robot_properties_fingers: Models of the (Tri-)Finger Robots"
 auto_general_docs = false
+
+[intersphinx.mapping]
+trifinger_docs = "https://open-dynamic-robot-initiative.github.io/trifinger_docs"

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,0 +1,7 @@
+************
+Installation
+************
+
+The ``robot_properties_fingers`` package is part of the TriFinger software
+bundle.  See :ref:`trifinger_docs:install_software` in the TriFinger
+documentation.

--- a/doc_mainpage.rst
+++ b/doc_mainpage.rst
@@ -1,5 +1,7 @@
 ``robot_properties_fingers`` contains the xacro model files for the various
-(Tri-)Finger robots as well as some Python utils to work with them.
+:doc:`(Tri-)Finger robots <trifinger_docs:index>` as well as some Python utils
+to work with them.
+
 
 The source code is hosted on GitHub_.  Please also use the `Bug Tracker`_ there
 if you have a question or want to report a bug.
@@ -12,6 +14,7 @@ Last rebuild of this documentation: |today|
    :caption: General Documentation
    :maxdepth: 1
 
+   doc/installation.rst
    doc/models.rst
 
 


### PR DESCRIPTION
Add a page with installation instructions that simply links to trifinger_docs.