### PR TITLE
fix: Remove duplicate interial of tip link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Python package with function `get_urdf_base_path()`
 - Moved Pinocchio-based `Kinematics` class from trifinger_simulation to this package.
 
+### Fixed
+- Removed duplicate inertial from FingerPro tip link.
+
 ## [1.1.0] - 2022-06-28
 
 There is no changelog for this or earlier versions.

--- a/xacro/pro/fingerpro_macro.xacro
+++ b/xacro/pro/fingerpro_macro.xacro
@@ -243,12 +243,6 @@
                 mesh_file="${tip_link_mesh}"
                 material="fingerpro_tip"
                 mesh_scale="1."/>
-            <xacro:add_inertia
-                length_x="0.01"
-                length_y="0.01"
-                length_z="0.01"
-                com="0 0 0"
-                mass="0.031"/>
 
             <inertial>
                 <origin rpy="0 0 0" xyz="-0.00001194 0.00000000 0.01560060"/>


### PR DESCRIPTION


## Description

Remove duplicate interial of tip link (seems I forgot to remove the old one here in b3f270f).


## How I Tested

Ran simulation with the TriFingerPro model to make sure there are no errors.