### PR TITLE
Fix missing URDF files in wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.0.2] - 2024-07-30
+### Fixed
+- URDF files where only added when installed from source but not included in the wheel
+  that is pushed to PyPI.  This is fixed now.
+
 ## [2.0.1] - 2024-07-30
 ### Changed
 - Converted to pure Python package.  You can still use the package in a colcon workspace
@@ -24,6 +29,7 @@ There is no changelog for this or earlier versions.
 
 ---
 
-[Unreleased]: https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/compare/v1.1.0...v2.0.1
 [1.1.0]: https://github.com/open-dynamic-robot-initiative/robot_properties_fingers/releases/tag/v1.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include xacro_files/ *.xacro

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>robot_properties_fingers</name>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <description>URDF files and meshes of the (Tri-)Finger robots.</description>
     <maintainer email="felix.widmaier@tue.mpg.de">Felix Widmaier</maintainer>
     <license>BSD-3-Clause</license>

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def load_readme() -> str:
 
 setup(
     name=package_name,
-    version="2.0.1",
+    version="2.0.2",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     package_data={"robot_properties_fingers": ["meshes/*.stl", "meshes/**/*.stl"]},


### PR DESCRIPTION
## Description

Add a MANIFEST.in, listing the xacro files.  Without this, they will not be included in the distribution archive generated by `python -m build`.

Bump version to 2.0.2.


## How I Tested

Built and inspected the resulting dist/ files.