### PR TITLE
Bump supported Python version and revise ruff rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install
         run: |
-          python3 -m pip install mypy types-PyYAML numpy==1.23.3
+          python3 -m pip install mypy types-PyYAML numpy==1.26.4
       - name: Add matcher
         run: |
           echo "::add-matcher::.github/workflows/mypy-problem-matcher.json"
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install ruff
         run: |
           python -m pip install --upgrade pip
@@ -42,5 +42,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - uses: psf/black@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Update pip
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Bump tested Python version to 3.12.
 
 ## [2.0.2] - 2024-07-30
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ lint.select = [
     "E", # pycodestyle
     "W", # pycodestyle
     "B", # bugbear
-    # "I", # isort
+    "I", # isort
     "N", # naming
     # "UP", # pyupgrade
     "A", # builtins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ ignore_missing_imports = true
 target-version = "py312"
 
 # for a complete list of available rules see https://docs.astral.sh/ruff/rules/
-# TODO commented-out rules below should be enabled but currently result in quite
-# a lot of warnings, which need to be fixed first.
 lint.select = [
     "F", # pyflakes
     "E", # pycodestyle
@@ -33,7 +31,7 @@ lint.select = [
     "B", # bugbear
     "I", # isort
     "N", # naming
-    # "UP", # pyupgrade
+    "UP", # pyupgrade
     "A", # builtins
     "FA", # future-annotations
     "G", # logging-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,43 +19,39 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.ruff]
-# enable all and disable a few via ignore below
-select = ["ALL"]
-extend-ignore = [
-    "BLE",
-    "COM",
-    "EM",
-    "FBT",
-    "INP",
-    "PTH",
-    "S",
-    "T20",
-    "UP",
-    "A003",
-    "ANN101",
-    "ANN102",
-    "ANN401",
-    "D105",
-    "D107",
-    "D205",
-    "D212",
-    "D417",
-    "G004",
-    "I001",
-    "N806",
-    "PLR0913",
-    "PTH123",
-    "RET505",
-    "TRY003",
-    "TRY400",
-]
-target-version = "py310"
 
-[tool.ruff.pydocstyle]
+[tool.ruff]
+target-version = "py312"
+
+# for a complete list of available rules see https://docs.astral.sh/ruff/rules/
+# TODO commented-out rules below should be enabled but currently result in quite
+# a lot of warnings, which need to be fixed first.
+lint.select = [
+    "F", # pyflakes
+    "E", # pycodestyle
+    "W", # pycodestyle
+    "B", # bugbear
+    # "I", # isort
+    "N", # naming
+    # "UP", # pyupgrade
+    "A", # builtins
+    "FA", # future-annotations
+    "G", # logging-format
+    "PT", # pytest-style
+    "SIM", # simplify
+    "ARG", # unused-arguments
+    "PL", # pylint
+    "NPY", # numpy
+    "RUF100",  # unused 'noqa' directive
+]
+lint.ignore = [
+    "N806",  # let's allow upper case variables for math stuff
+]
+
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*.pyi" = ["ALL"]
 "__init__.py" = ["F401"]  # unused imports
 "tests/*" = ["D", "ANN", "PLR2004"]

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,9 @@
 import pathlib
 from os import path
 
+import xacro
 from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
-
-import xacro
 
 package_name = "robot_properties_fingers"
 

--- a/src/robot_properties_fingers/pinocchio_utils.py
+++ b/src/robot_properties_fingers/pinocchio_utils.py
@@ -18,7 +18,7 @@ class Kinematics:
 
     def __init__(
         self,
-        finger_urdf_path: typing.Union[str, os.PathLike],
+        finger_urdf_path: str | os.PathLike,
         tip_link_names: typing.Iterable[str],
     ) -> None:
         """
@@ -34,12 +34,9 @@ class Kinematics:
 
     def forward_kinematics(
         self,
-        joint_positions: typing.List[np.ndarray],
-        joint_velocities: typing.Optional[np.ndarray] = None,
-    ) -> typing.Union[
-        typing.List[np.ndarray],
-        typing.Tuple[typing.List[np.ndarray], typing.List[np.ndarray]],
-    ]:
+        joint_positions: list[np.ndarray],
+        joint_velocities: np.ndarray | None = None,
+    ) -> list[np.ndarray] | tuple[list[np.ndarray], list[np.ndarray]]:
         """Compute end-effector positions and velocities.
 
         Compute position and optionally velocity of the end-effector(s) given angular
@@ -83,7 +80,7 @@ class Kinematics:
 
     def _inverse_kinematics_step(
         self, frame_id: int, xdes: np.ndarray, q0: np.ndarray
-    ) -> typing.Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Compute one IK iteration for a single finger."""
         dt = 1.0e-1
         pinocchio.computeJointJacobians(self.robot_model, self.data, q0)
@@ -111,7 +108,7 @@ class Kinematics:
         joint_angles_guess: np.ndarray,
         tolerance: float = 0.005,
         max_iterations: int = 1000,
-    ) -> typing.Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Inverse kinematics for a single finger.
 
         Args:
@@ -144,7 +141,7 @@ class Kinematics:
         joint_angles_guess: np.ndarray,
         tolerance: float = 0.005,
         max_iterations: int = 1000,
-    ) -> typing.Tuple[np.ndarray, typing.List[np.ndarray]]:
+    ) -> tuple[np.ndarray, list[np.ndarray]]:
         """Inverse kinematics for the whole manipulator.
 
         Args:

--- a/src/robot_properties_fingers/pinocchio_utils.py
+++ b/src/robot_properties_fingers/pinocchio_utils.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import typing
 import os
+import typing
 
 import numpy as np
 import pinocchio

--- a/tests/test_pinocchio_utils.py
+++ b/tests/test_pinocchio_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import robot_properties_fingers as pf
 
 
-@pytest.fixture()
+@pytest.fixture
 def kinematics() -> pf.Kinematics:
     urdf_file = pf.get_urdf_base_path("pro") / "trifingerpro.urdf"
 

--- a/tests/test_pinocchio_utils.py
+++ b/tests/test_pinocchio_utils.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 
 import robot_properties_fingers as pf
 


### PR DESCRIPTION
## Description

- Bump supported Python version to 3.12 (matching the official Apptainer image for the TriFinger project).  Other versions may work as well but are not tested.
- Revise ruff lint rules.  Using an explicit select list instead of "ALL" avoids new errors popping up as ruff adds more rules in new releases.